### PR TITLE
Adding changes for configuration options and cleaning up code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/coffeescript-compiler-grailsPlugins.iml
+/*.iml
 /.idea
 /.settings
 /.classpath
@@ -6,3 +6,4 @@
 /coffeescript-compiler.iml
 /target
 /out
+/grails-app/i18n

--- a/CoffeescriptCompilerGrailsPlugin.groovy
+++ b/CoffeescriptCompilerGrailsPlugin.groovy
@@ -1,107 +1,93 @@
 import grails.util.Environment
 import org.grails.plugins.coffee.compiler.CoffeeCompilerManager
 
-class CoffeescriptCompilerGrailsPlugin
-{
-	// the plugin version
-	def version = "0.6"
-	// the version or versions of Grails the plugin is designed for
-	def grailsVersion = "2.1 > *"
-	// the other plugins this plugin depends on
-	def dependsOn = [:]
-	// resources that are excluded from plugin packaging
-	def pluginExcludes = [
-			"grails-app/views/error.gsp"
-	]
+class CoffeescriptCompilerGrailsPlugin {
+    // the plugin version
+    def version = "0.7"
+    // the version or versions of Grails the plugin is designed for
+    def grailsVersion = "2.1 > *"
+    // the other plugins this plugin depends on
+    def dependsOn = [:]
+    // resources that are excluded from plugin packaging
+    def pluginExcludes = [
+            'grails-app/conf/spring/resources.groovy',
+            'grails-app/conf/codenarc.groovy',
+            'grails-app/conf/codenarc.ruleset.all.groovy.txt',
+            'grails-app/domain/**',
+            'grails-app/i18n/**',
+            'grails-app/services/**',
+            'grails-app/views/**',
+            'web-app/**',
+            'codenarc.properties'
+    ]
 
-	def title = "Coffeescript Compiler Plugin" // Headline display name of the plugin
-	def author = "Brian Kotek"
-	def authorEmail = ""
-	def description = '''\
+    def title = "Coffeescript Compiler Plugin" // Headline display name of the plugin
+    def author = "Brian Kotek"
+    def authorEmail = ""
+    def description = '''\
 A simple CoffeeScript 1.4 compiler plugin. It compiles .coffee source files into .js files, and does not require NodeJS or CoffeeScript to be installed on your machine. Leaves you with full control over if/how to use these generated .js files as resources, etc. Full documentation at: https://github.com/brian428/grails-coffeescript-compiler-plugin.
 '''
 
-	// URL to the plugin's documentation
-	def documentation = "https://github.com/brian428/grails-coffeescript-compiler-plugin"
+    def developers = [
+            [name: "Christian Oestreich", email: "acetrike@gmail.com"]
+    ]
 
-	// License: one of 'APACHE', 'GPL2', 'GPL3'
+    // URL to the plugin's documentation
+    def documentation = "https://github.com/brian428/grails-coffeescript-compiler-plugin"
+
+    // License: one of 'APACHE', 'GPL2', 'GPL3'
     def license = "APACHE"
 
-	// Details of company behind the plugin (if there is one)
-    def organization = [ name: "Brian Kotek", url: "http://www.briankotek.com/" ]
+    // Details of company behind the plugin (if there is one)
+    def organization = [name: "Brian Kotek", url: "http://www.briankotek.com/"]
 
-	// Any additional developers beyond the author specified above.
+    // Any additional developers beyond the author specified above.
 //    def developers = [ [ name: "Joe Bloggs", email: "joe@bloggs.net" ]]
 
-	// Location of the plugin's issue tracker.
-    def issueManagement = [ system: "Github", url: "https://github.com/brian428/grails-coffeescript-compiler-plugin/issues" ]
+    // Location of the plugin's issue tracker.
+    def issueManagement = [system: "Github", url: "https://github.com/brian428/grails-coffeescript-compiler-plugin/issues"]
 
-	// Online location of the plugin's browseable source code.
-    def scm = [ url: "https://github.com/brian428/grails-coffeescript-compiler-plugin" ]
+    // Online location of the plugin's browseable source code.
+    def scm = [url: "https://github.com/brian428/grails-coffeescript-compiler-plugin"]
 
-	// Don't compile when running Grails tests.
-	def environments = [ excludes:"test" ]
-	def scopes = [ excludes: [ "functional_test", "test" ] ]
+    // Don't compile when running Grails tests.
+    def environments = [excludes: "test"]
+    def scopes = [excludes: ["functional_test", "test"]]
 
-	// Watch for changes to any .coffee files under /src or /web-app to recompile at runtime.
-	def watchedResources = [ "file:./src/*.coffee", "file:./src/**/*.coffee", "file:./web-app/*.coffee", "file:./web-app/**/*.coffee" ]
+    // Watch for changes to any .coffee files under /src or /web-app to recompile at runtime.
+    def watchedResources = ["file:./src/*.coffee", "file:./src/**/*.coffee", "file:./web-app/*.coffee", "file:./web-app/**/*.coffee"]
 
-	// Set up compiler manager. Default paths defined in CoffeeCompilerManager can be overridden with constructor args.
-	def coffeeCompilerManager = new CoffeeCompilerManager()
-	def startUpComplete = false
+    // Set up compiler manager. Default paths defined in CoffeeCompilerManager can be overridden with constructor args.
+    def coffeeCompilerManager = new CoffeeCompilerManager()
+    def startUpComplete = false
 
-	def doWithWebDescriptor = { xml ->
-		if( !startUpComplete )
-		{
-			def thisPluginConfig = [:]
+    def doWithWebDescriptor = { xml ->
+        if(!startUpComplete) {
+            def thisPluginConfig = [:]
 
-			if( application.config.containsKey( "coffeescript-compiler" ) && application.config."coffeescript-compiler".containsKey( "pluginConfig" ) )
-			{
-				thisPluginConfig = application.config."coffeescript-compiler".pluginConfig
-				application.config."coffeescript-compiler".remove( "pluginConfig" )
-			}
+            if(application?.config?."coffeescript-compiler"?.pluginConfig) {
+                thisPluginConfig = application.config."coffeescript-compiler".pluginConfig
+                application.config."coffeescript-compiler".remove("pluginConfig")
+            }
 
-			if( thisPluginConfig.containsKey( "minifyInEnvironment" ) )
-			{
-				coffeeCompilerManager.minifyJS = thisPluginConfig.minifyInEnvironment.contains( Environment.current.toString() )
-			}
-			else
-			{
-				coffeeCompilerManager.minifyJS = Environment.current == Environment.PRODUCTION
-			}
+            coffeeCompilerManager.minifyJS = (thisPluginConfig.containsKey("minifyInEnvironment")) ?
+                                             thisPluginConfig.minifyInEnvironment.contains(Environment.current.toString()) :
+                                             Environment.current == Environment.PRODUCTION
 
-			coffeeCompilerManager.compileFromConfig( application.config )
-			startUpComplete = true
-		}
-	}
+            //default the purge to true
+            coffeeCompilerManager.purgeJS = (thisPluginConfig.containsKey("purgeJS")) ? thisPluginConfig.purgeJS as Boolean : true
+            coffeeCompilerManager.wrapJS = (thisPluginConfig.containsKey("wrapJS")) ? thisPluginConfig.wrapJS as Boolean : true
+            coffeeCompilerManager.overrideJS = (thisPluginConfig.containsKey("overrideJS")) ? thisPluginConfig.overrideJS as Boolean : true
+            coffeeCompilerManager.compileFromConfig(application.config)
+            startUpComplete = true
+        }
+    }
 
-	def doWithSpring = {
-		// TODO Implement runtime spring config (optional)
-	}
+    def onChange = { event ->
+        def changedFile = event.source.file
 
-	def doWithDynamicMethods = { ctx ->
-		// TODO Implement registering dynamic methods to classes (optional)
-	}
-
-	def doWithApplicationContext = { applicationContext ->
-		// TODO Implement post initialization spring config (optional)
-	}
-
-	def onChange = { event ->
-		def changedFile = event.source.file
-
-		if( changedFile.path.contains( ".coffee" ) )
-		{
-			coffeeCompilerManager.compileFileFromConfig( changedFile, application.config )
-		}
-	}
-
-	def onConfigChange = { event ->
-		// TODO Implement code that is executed when the project configuration changes.
-		// The event is the same as for 'onChange'.
-	}
-
-	def onShutdown = { event ->
-		// TODO Implement code that is executed when the application shuts down (optional)
-	}
+        if(changedFile.path.contains(".coffee")) {
+            coffeeCompilerManager.compileFileFromConfig(changedFile, application.config)
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -60,4 +60,42 @@ By default, the generated JavaScript is unminified in the `DEVELOPMENT` environm
 }
 ```
 
-The CoffeeScript compilation is excluded from the "test" and "functional_test" scopes. 
+To cause the compiler to use a "--no-wrap" simply add the following to your config which will cause the resulting JavaScript to **not** include the `.call()` wrapper.
+
+```groovy
+"coffeescript-compiler" {
+	pluginConfig {
+	    wrapJS = false
+	}
+}
+```
+
+**CAUTION** By default the plugin will purge the js folder on startup.  If you wish for your JavaScript and CoffeeScript to live happily together in your application or in the same folder simply add the `purgeJS=false` to the config.
+
+```groovy
+"coffeescript-compiler" {
+	pluginConfig {
+	    purgeJS = false
+	}
+}
+```
+
+By default the plugin on startup will process any `*.coffee` files whose companion `*.js` file has a newer timestamp.  If you wish to disable this feature to skip recompile on startup.
+
+```groovy
+"coffeescript-compiler" {
+	pluginConfig {
+	    overrideJS = false
+	}
+}
+```
+
+The CoffeeScript compilation is excluded from the "test" and "functional_test" scopes.
+
+Which compiler is used?
+-------------------------
+The default compiler is Rhino, but if you have node coffee-script installed that will be used instead.  Hopefully this does not cause any variances amongst environments with and without node coffee-script, but note that is COULD.
+
+If you wish to use node as the default you can install it as the following.
+
+`npm install -g coffee-script`

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,5 @@
 #Grails Metadata file
-#Thu Jan 10 23:18:11 EST 2013
-app.grails.version=2.1.0
+#Fri Feb 08 09:47:45 CST 2013
+app.grails.version=2.1.3
 app.name=coffeescript-compiler
+plugins.hibernate=2.1.3

--- a/codenarc.properties
+++ b/codenarc.properties
@@ -1,0 +1,1 @@
+GrailsStatelessService.ignoreFieldNames=grailsApplication,applicationContext,dataSource,scope,sessionFactory,transactional,*Service,messageSource,s3Credential,applicationContext,expose,profiled,connectionFactory,soapClient,httpClient,objectFactory,jaxbContext,*Mapper,*Adaptor

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,27 +21,27 @@ grails.project.dependency.resolution = {
         //mavenRepo "http://repository.jboss.com/maven2/"
     }
     dependencies {
-		runtime( "ro.isdc.wro4j:wro4j-extensions:1.6.0" ) {
-			excludes(
-					"slf4j-log4j12",
-					"spring-web",
-					"gmaven-runtime-1.6",
-					"gmaven-runtime-1.7",
-					"servlet-api",
-					"ant",
-					"groovy-all",
-					"jsp-api",
-					"commons-pool",
-					"spring-web",
-					"gson",
-					"closure-compiler",
-					"dojo-shrinksafe",
-					"jruby-complete",
-					"sass-gems",
-					"bourbon-gem-jar",
-					"less4j"
-			)
-		}
+        runtime("ro.isdc.wro4j:wro4j-extensions:1.6.2") {
+            excludes(
+                    "slf4j-log4j12",
+                    "spring-web",
+                    "gmaven-runtime-1.6",
+                    "gmaven-runtime-1.7",
+                    "servlet-api",
+                    "ant",
+                    "groovy-all",
+                    "jsp-api",
+                    "commons-pool",
+                    "spring-web",
+                    "gson",
+                    "closure-compiler",
+                    "dojo-shrinksafe",
+                    "jruby-complete",
+                    "sass-gems",
+                    "bourbon-gem-jar",
+                    "less4j"
+            )
+        }
     }
 
     plugins {
@@ -50,5 +50,32 @@ grails.project.dependency.resolution = {
               ":rest-client-builder:1.0.2") {
             export = false
         }
+
+        test(":spock:0.6",
+             ":code-coverage:1.2.5",
+             ":codenarc:0.17") {
+            export = false
+        }
     }
 }
+
+coverage {
+    xml = true
+    exclusions = ['**/*Tests*']
+}
+
+codenarc {
+    processTestUnit = false
+    processTestIntegration = false
+    processServices = false
+    processDomain = false
+    propertiesFile = 'codenarc.properties'
+    ruleSetFiles = 'file:grails-app/conf/codenarc.groovy'
+    reports = {
+        CoffeeScriptCompilerReport('xml') {                    // The report name 'MyXmlReport' is user-defined; Report type is 'xml'
+            outputFile = 'target/codenarc.xml'      // Set the 'outputFile' property of the (XML) Report
+            title = 'Grails CoffeeScript Compiler Plugin'             // Set the 'title' property of the (XML) Report
+        }
+    }
+}
+

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -22,3 +22,5 @@ log4j = {
 
     warn   'org.mortbay.log'
 }
+grails.views.default.codec="none" // none, html, base64
+grails.views.gsp.encoding="UTF-8"

--- a/grails-app/conf/codenarc.groovy
+++ b/grails-app/conf/codenarc.groovy
@@ -1,0 +1,21 @@
+ruleset {
+
+    description 'CodeNarc RuleSet'
+
+//    ruleset( "http://codenarc.sourceforge.net/StarterRuleSet-AllRulesByCategory.groovy.txt" ) {
+    ruleset("file:grails-app/conf/codenarc.ruleset.all.groovy.txt") {
+        DuplicateNumberLiteral   ( enabled : false )
+        DuplicateStringLiteral   ( enabled : false )
+        BracesForClass           ( enabled : false )
+        BracesForMethod          ( enabled : false )
+        BracesForIfElse          ( enabled : false )
+        BracesForForLoop         ( enabled : false )
+        BracesForTryCatchFinally ( enabled : false )
+        JavaIoPackageAccess      ( enabled : false )
+        ThrowRuntimeException    ( enabled : false )
+        CatchException           ( enabled : false )
+        LineLength               ( length              : 220 )
+        MethodName               ( regex               : /[a-z][\w\s'\(\)]*/ ) // Spock method names
+
+    }
+}

--- a/grails-app/conf/codenarc.ruleset.all.groovy.txt
+++ b/grails-app/conf/codenarc.ruleset.all.groovy.txt
@@ -1,0 +1,336 @@
+ruleset {
+
+    description '''
+        A Sample Groovy RuleSet containing all CodeNarc Rules, grouped by category.
+        You can use this as a template for your own custom RuleSet.
+        Just delete the rules that you don't want to include.
+        '''
+
+    // rulesets/basic.xml
+    AssertWithinFinallyBlock
+    AssignmentInConditional
+    BigDecimalInstantiation
+    BitwiseOperatorInConditional
+    BooleanGetBoolean
+    BrokenNullCheck
+    BrokenOddnessCheck
+    ClassForName
+    ComparisonOfTwoConstants
+    ComparisonWithSelf
+    ConstantAssertExpression
+    ConstantIfExpression
+    ConstantTernaryExpression
+    DeadCode
+    DoubleNegative
+    DuplicateCaseStatement
+    DuplicateMapKey
+    DuplicateSetValue
+    EmptyCatchBlock
+    EmptyElseBlock
+    EmptyFinallyBlock
+    EmptyForStatement
+    EmptyIfStatement
+    EmptyInstanceInitializer
+    EmptyMethod
+    EmptyStaticInitializer
+    EmptySwitchStatement
+    EmptySynchronizedStatement
+    EmptyTryBlock
+    EmptyWhileStatement
+    EqualsAndHashCode
+    EqualsOverloaded
+    ExplicitGarbageCollection
+    ForLoopShouldBeWhileLoop
+    HardCodedWindowsFileSeparator
+    HardCodedWindowsRootDirectory
+    IntegerGetInteger
+    RandomDoubleCoercedToZero
+    RemoveAllOnSelf
+    ReturnFromFinallyBlock
+    ThrowExceptionFromFinallyBlock
+
+    // rulesets/braces.xml
+    ElseBlockBraces
+    ForStatementBraces
+    IfStatementBraces
+    WhileStatementBraces
+
+    // rulesets/concurrency.xml
+    BusyWait
+    DoubleCheckedLocking
+    InconsistentPropertyLocking
+    InconsistentPropertySynchronization
+    NestedSynchronization
+    StaticCalendarField
+    StaticConnection
+    StaticDateFormatField
+    StaticMatcherField
+    StaticSimpleDateFormatField
+    SynchronizedMethod
+    SynchronizedOnBoxedPrimitive
+    SynchronizedOnGetClass
+    SynchronizedOnReentrantLock
+    SynchronizedOnString
+    SynchronizedOnThis
+    SynchronizedReadObjectMethod
+    SystemRunFinalizersOnExit
+    ThreadGroup
+    ThreadLocalNotStaticFinal
+    ThreadYield
+    UseOfNotifyMethod
+    VolatileArrayField
+    VolatileLongOrDoubleField
+    WaitOutsideOfWhileLoop
+
+    // rulesets/convention.xml
+    ConfusingTernary
+    CouldBeElvis
+    HashtableIsObsolete
+    InvertedIfElse
+    LongLiteralWithLowerCaseL
+    ParameterReassignment
+    TernaryCouldBeElvis
+    VectorIsObsolete
+
+    // rulesets/design.xml
+    AbstractClassWithPublicConstructor
+    AbstractClassWithoutAbstractMethod
+    BooleanMethodReturnsNull
+    BuilderMethodWithSideEffects
+    CloneableWithoutClone
+    CloseWithoutCloseable
+    CompareToWithoutComparable
+    ConstantsOnlyInterface
+    EmptyMethodInAbstractClass
+    FinalClassWithProtectedMember
+    ImplementationAsType
+    PrivateFieldCouldBeFinal
+    PublicInstanceField
+    ReturnsNullInsteadOfEmptyArray
+    ReturnsNullInsteadOfEmptyCollection
+    SimpleDateFormatMissingLocale
+    StatelessSingleton
+
+    // rulesets/dry.xml
+    DuplicateListLiteral
+    DuplicateMapLiteral
+    DuplicateNumberLiteral
+    DuplicateStringLiteral
+
+    // rulesets/exceptions.xml
+    CatchArrayIndexOutOfBoundsException
+    CatchError
+    CatchException
+    CatchIllegalMonitorStateException
+    CatchIndexOutOfBoundsException
+    CatchNullPointerException
+    CatchRuntimeException
+    CatchThrowable
+    ConfusingClassNamedException
+    ExceptionExtendsError
+    MissingNewInThrowStatement
+    ReturnNullFromCatchBlock
+    SwallowThreadDeath
+    ThrowError
+    ThrowException
+    ThrowNullPointerException
+    ThrowRuntimeException
+    ThrowThrowable
+
+    // rulesets/formatting.xml
+    BracesForClass
+    BracesForForLoop
+    BracesForIfElse
+    BracesForMethod
+    BracesForTryCatchFinally
+    ClassJavadoc
+    LineLength
+
+    // rulesets/generic.xml
+    IllegalClassReference
+    IllegalPackageReference
+    IllegalRegex
+    RequiredRegex
+    RequiredString
+    StatelessClass
+
+    // rulesets/grails.xml
+    GrailsDomainHasEquals
+    GrailsDomainHasToString
+    GrailsPublicControllerMethod
+    GrailsServletContextReference
+    GrailsSessionReference
+    GrailsStatelessService
+
+    // rulesets/groovyism.xml
+    AssignCollectionSort
+    AssignCollectionUnique
+    ClosureAsLastMethodParameter
+    CollectAllIsDeprecated
+    ConfusingMultipleReturns
+    ExplicitArrayListInstantiation
+    ExplicitCallToAndMethod
+    ExplicitCallToCompareToMethod
+    ExplicitCallToDivMethod
+    ExplicitCallToEqualsMethod
+    ExplicitCallToGetAtMethod
+    ExplicitCallToLeftShiftMethod
+    ExplicitCallToMinusMethod
+    ExplicitCallToModMethod
+    ExplicitCallToMultiplyMethod
+    ExplicitCallToOrMethod
+    ExplicitCallToPlusMethod
+    ExplicitCallToPowerMethod
+    ExplicitCallToRightShiftMethod
+    ExplicitCallToXorMethod
+    ExplicitHashMapInstantiation
+    ExplicitHashSetInstantiation
+    ExplicitLinkedHashMapInstantiation
+    ExplicitLinkedListInstantiation
+    ExplicitStackInstantiation
+    ExplicitTreeSetInstantiation
+    GStringAsMapKey
+    GetterMethodCouldBeProperty
+    GroovyLangImmutable
+    UseCollectMany
+    UseCollectNested
+
+    // rulesets/imports.xml
+    DuplicateImport
+    ImportFromSamePackage
+    ImportFromSunPackages
+    MisorderedStaticImports
+    UnnecessaryGroovyImport
+    UnusedImport
+
+    // rulesets/jdbc.xml
+    DirectConnectionManagement
+    JdbcConnectionReference
+    JdbcResultSetReference
+    JdbcStatementReference
+
+    // rulesets/junit.xml
+    ChainedTest
+    CoupledTestCase
+    JUnitAssertAlwaysFails
+    JUnitAssertAlwaysSucceeds
+    JUnitFailWithoutMessage
+    JUnitPublicNonTestMethod
+    JUnitSetUpCallsSuper
+    JUnitStyleAssertions
+    JUnitTearDownCallsSuper
+    JUnitTestMethodWithoutAssert
+    JUnitUnnecessarySetUp
+    JUnitUnnecessaryTearDown
+    SpockIgnoreRestUsed
+    UnnecessaryFail
+    UseAssertEqualsInsteadOfAssertTrue
+    UseAssertFalseInsteadOfNegation
+    UseAssertNullInsteadOfAssertEquals
+    UseAssertSameInsteadOfAssertTrue
+    UseAssertTrueInsteadOfAssertEquals
+    UseAssertTrueInsteadOfNegation
+
+    // rulesets/logging.xml
+    LoggerForDifferentClass
+    LoggerWithWrongModifiers
+    LoggingSwallowsStacktrace
+    MultipleLoggers
+    PrintStackTrace
+    Println
+    SystemErrPrint
+    SystemOutPrint
+
+    // rulesets/naming.xml
+    AbstractClassName
+    ClassName
+    ConfusingMethodName
+    FactoryMethodName
+    FieldName
+    InterfaceName
+    MethodName
+    ObjectOverrideMisspelledMethodName
+    PackageName
+    ParameterName
+    PropertyName
+    VariableName
+
+    // rulesets/security.xml
+    FileCreateTempFile
+    InsecureRandom
+    JavaIoPackageAccess
+    NonFinalPublicField
+    NonFinalSubclassOfSensitiveInterface
+    ObjectFinalize
+    PublicFinalizeMethod
+    SystemExit
+    UnsafeArrayDeclaration
+
+    // rulesets/serialization.xml
+    SerialPersistentFields
+    SerialVersionUID
+    SerializableClassMustDefineSerialVersionUID
+
+    // rulesets/size.xml
+    AbcComplexity
+    ClassSize
+    CrapMetric
+    CyclomaticComplexity
+    MethodCount
+    MethodSize
+    NestedBlockDepth
+
+    // rulesets/unnecessary.xml
+    AddEmptyString
+    ConsecutiveLiteralAppends
+    ConsecutiveStringConcatenation
+    UnnecessaryBigDecimalInstantiation
+    UnnecessaryBigIntegerInstantiation
+    UnnecessaryBooleanExpression
+    UnnecessaryBooleanInstantiation
+    UnnecessaryCallForLastElement
+    UnnecessaryCallToSubstring
+    UnnecessaryCatchBlock
+    UnnecessaryCollectCall
+    UnnecessaryCollectionCall
+    UnnecessaryConstructor
+    UnnecessaryDefInFieldDeclaration
+    UnnecessaryDefInMethodDeclaration
+    UnnecessaryDefInVariableDeclaration
+    UnnecessaryDotClass
+    UnnecessaryDoubleInstantiation
+    UnnecessaryElseStatement
+    UnnecessaryFinalOnPrivateMethod
+    UnnecessaryFloatInstantiation
+    UnnecessaryGString
+    UnnecessaryGetter
+    UnnecessaryIfStatement
+    UnnecessaryInstanceOfCheck
+    UnnecessaryInstantiationToGetClass
+    UnnecessaryIntegerInstantiation
+    UnnecessaryLongInstantiation
+    UnnecessaryModOne
+    UnnecessaryNullCheck
+    UnnecessaryNullCheckBeforeInstanceOf
+    UnnecessaryObjectReferences
+    UnnecessaryOverridingMethod
+    UnnecessaryPackageReference
+    UnnecessaryParenthesesForMethodCallWithClosure
+    UnnecessaryPublicModifier
+    UnnecessaryReturnKeyword
+    UnnecessarySelfAssignment
+    UnnecessarySemicolon
+    UnnecessaryStringInstantiation
+    UnnecessarySubstring
+    UnnecessaryTernaryExpression
+    UnnecessaryTransientModifier
+
+    // rulesets/unused.xml
+    UnusedArray
+    UnusedMethodParameter
+    UnusedObject
+    UnusedPrivateField
+    UnusedPrivateMethod
+    UnusedPrivateMethodParameter
+    UnusedVariable
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<plugin name='coffeescript-compiler' version='0.6' grailsVersion='2.1 &gt; *'>
+<plugin name='coffeescript-compiler' version='0.13' grailsVersion='2.1 &gt; *'>
   <author>Brian Kotek</author>
   <title>Coffeescript Compiler Plugin</title>
   <description>A simple CoffeeScript 1.4 compiler plugin. It compiles .coffee source files into .js files, and does not require NodeJS or CoffeeScript to be installed on your machine. Leaves you with full control over if/how to use these generated .js files as resources, etc. Full documentation at: https://github.com/brian428/grails-coffeescript-compiler-plugin.
@@ -13,7 +13,7 @@
   </repositories>
   <dependencies>
     <runtime>
-      <dependency group='ro.isdc.wro4j' name='wro4j-extensions' version='1.6.0' />
+      <dependency group='ro.isdc.wro4j' name='wro4j-extensions' version='1.6.2' />
     </runtime>
   </dependencies>
   <plugins />

--- a/src/groovy/org/grails/plugins/coffee/compiler/CoffeeCompiler.groovy
+++ b/src/groovy/org/grails/plugins/coffee/compiler/CoffeeCompiler.groovy
@@ -1,140 +1,166 @@
 package org.grails.plugins.coffee.compiler
 
-import ro.isdc.wro.extensions.processor.js.CoffeeScriptProcessor
+import org.apache.commons.io.FileUtils
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+import org.grails.plugins.coffee.compiler.processor.CoffeeScriptProcessor
+import ro.isdc.wro.WroRuntimeException
+import ro.isdc.wro.config.Context
+import ro.isdc.wro.config.jmx.WroConfiguration
 import ro.isdc.wro.extensions.processor.js.UglifyJsProcessor
+import ro.isdc.wro.model.group.processor.Injector
+import ro.isdc.wro.model.group.processor.InjectorBuilder
 import ro.isdc.wro.model.resource.Resource
 import ro.isdc.wro.model.resource.ResourceType
 
-import java.util.concurrent.*
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
-class CoffeeCompiler
-{
+class CoffeeCompiler {
 
-	// Default values for CoffeeScript source and JavaScript output paths
-	String coffeeSourcePath = "src/coffee"
-	String jsOutputPath = "web-app/js/app"
-	Long minutesToWaitForComplete = 3
-	Integer threadPoolSize = 10
+    private static final Log log = LogFactory.getLog(CoffeeCompiler.class)
 
-	CoffeeCompiler( String configCoffeeSourcePath, String configJsOutputPath )
-	{
-		if( configCoffeeSourcePath )
-			coffeeSourcePath = configCoffeeSourcePath
-		if( configJsOutputPath )
-			jsOutputPath = configJsOutputPath
-	}
+    // Default values for CoffeeScript source and JavaScript output paths
+    String coffeeSourcePath = 'src/coffee'
+    String jsOutputPath = 'web-app/js/app'
+    private final Long MINUTES_TO_WAIT_FOR_COMPLETE = 3
+    private final Integer THREAD_POOL_SIZE = 10
 
-	def compileFile( File file, minifyJS=false )
-	{
-		if( !file )
-			return
+    CoffeeCompiler(String configCoffeeSourcePath, String configJsOutputPath) {
+        coffeeSourcePath = configCoffeeSourcePath ?: coffeeSourcePath
+        jsOutputPath = configJsOutputPath ?: jsOutputPath
+    }
 
-		def rawContent = []
-		rawContent << file.getText()
-		def content = rawContent.join( System.getProperty( "line.separator" ) )
+    def compileFile(File file, Boolean minifyJS = false, Boolean wrapJS = true, Boolean overrideJS = true) {
+        if(!file) {
+            return
+        }
 
-		String outputFileName = file.path.replace( '\\', '/' ).replace( coffeeSourcePath, jsOutputPath ).replace( ".coffee", ".js" )
-		File outputFile = new File( outputFileName )
-		new File( outputFile.parent ).mkdirs()
+        String outputFileName = file.path.replace('\\', '/').replace(coffeeSourcePath, jsOutputPath).replace('.coffee', '.js')
 
-		Resource resource = Resource.create( file.path, ResourceType.JS );
-		Reader reader = new FileReader( file.path );
-		Writer writer = new FileWriter( outputFile.path );
+        File outputFile = new File(outputFileName)
 
-		try
-		{
-			new CoffeeScriptProcessor().process( resource, reader, writer );
-			if( minifyJS )
-			{
-				minify( outputFile )
-				System.out.println( "Compiling and minifying ${file.path} to ${outputFile.path}" )
-			}
-			else
-				System.out.println( "Compiling ${file.path} to ${outputFile.path}" )
+        //move on if flag is not set to override AND js is newer
+        if(!overrideJS && isJavascriptNewerThanCoffee(outputFile, file)) {
+            return
+        }
 
-		}
-		catch( Exception e )
-		{
-			System.out.println( " " )
-			System.out.println( "${e.message} in ${file.path}" )
-			System.out.println( " " )
-			throw e
-		}
-	}
+        new File(outputFile.parent).mkdirs()
 
-	def compileAll( minifyJS=false )
-	{
-		System.out.println( "Purging ${jsOutputPath}..." )
-		new File( jsOutputPath ).deleteDir()
-		new File( jsOutputPath ).mkdirs()
-		def coffeeSource = new File( coffeeSourcePath )
+        Resource resource = Resource.create(file.path, ResourceType.JS)
+        Reader reader = file.newReader()
+        Writer writer = outputFile.newWriter()
 
-		def pool = Executors.newFixedThreadPool( threadPoolSize )
-		def defer = { c -> pool.submit( c as Callable ) }
+        try {
+            /*
+            note: this is needed when Node is used by wro4j and we wish to "override" the bare/noWrap options.
+            The default processor is Rhino in cases where it can't find node so we have to account for both... and luck
+            has it that they deal with compiler options in a COMPLETELY different way.  *yeah*
+            */
+            Context.set(Context.standaloneContext(), new WroConfiguration())
+            Injector injector = new InjectorBuilder().build()
+            CoffeeScriptProcessor coffee = new CoffeeScriptProcessor(wrapJS)
+            injector.inject(coffee)
+            coffee.process(resource, reader, writer)
 
-		def eachFileHandler = { File file ->
-			if( file.isDirectory() )
-			{
-				return
-			}
+            if(minifyJS) {
+                minify(outputFile)
+            }
 
-			if( file.path.contains( ".coffee" ) )
-			{
-				defer{ compileFile( file, minifyJS ) }
-			}
-		}
+            log.debug "Compiling ${minifyJS ? ' and minifying ' : ''} ${file.path} to ${outputFile.path}"
 
-		def ignoreHidden = { File file ->
-			if( file.isHidden() )
-			{
-				return false;
-			}
-			return true;
-		}
 
-		eachFileRecurse( coffeeSource, eachFileHandler, ignoreHidden )
+        } catch(WroRuntimeException wroRuntimeException) {
+            FileUtils.deleteQuietly(outputFile)
+            log.error "${wroRuntimeException.message} in ${file.path}"
+            throw wroRuntimeException
+        } catch(NullPointerException npe) {
+            FileUtils.deleteQuietly(outputFile)
+            log.error "${npe.message} in ${file.path}"
+            throw new WroRuntimeException(npe.message, npe)
+        } catch(Exception e) {
+            FileUtils.deleteQuietly(outputFile)
+            log.error "${e.message} in ${file.path}"
+            throw new WroRuntimeException(e.message, e)
+        } finally {
+            reader.close()
+            writer.close()
+        }
+    }
 
-		pool.shutdown()
-		pool.awaitTermination( minutesToWaitForComplete, TimeUnit.MINUTES )
+/**
+ * Test of the JavaScript file was modified since last coffee compile.  This is a bad
+ * situation to get into, but sometimes on rare occasions debugging is quicker by modifying
+ * the js directly.  Arguably people should not do this, but ho-hum they do.
+ * @param outputFile The javascript file
+ * @param sourceFile The coffee file
+ * @return true if javascript file is newer than coffee file
+ */
+    Boolean isJavascriptNewerThanCoffee(File outputFile, File sourceFile) {
+        Boolean isJavascriptNewer = (outputFile.exists() && outputFile.lastModified() > sourceFile.lastModified())
+        if(isJavascriptNewer) {
+            //output message to stdout
+            log.debug "JavaScript file ${outputFile.absolutePath} is newer than ${sourceFile.absolutePath}, skipping compile."
+        }
+        isJavascriptNewer
+    }
 
-	}
+    def compileAll(Boolean minifyJS = false, Boolean purgeJS = true, Boolean wrapJS = true, Boolean overrideJS = true) {
+        if(purgeJS) {
+            log.debug "Purging ${jsOutputPath}..."
+            new File(jsOutputPath).deleteDir()
+        }
+        new File(jsOutputPath).mkdirs()
+        def coffeeSource = new File(coffeeSourcePath)
 
-	def eachFileRecurse( File dir, Closure closure, Closure filter = { return true } )
-	{
-		for( file in dir.listFiles() )
-		{
-			if( filter.call( file ) )
-			{
-				if ( file.isDirectory() )
-				{
-					eachFileRecurse( file, closure, filter );
-				}
-				else
-				{
-					closure.call( file );
-				}
-			}
-		}
-	}
+        def pool = Executors.newFixedThreadPool(THREAD_POOL_SIZE)
+        def defer = { c -> pool.submit(c as Callable) }
 
-	def minify( File inputFile )
-	{
-		File targetFile = new File( inputFile.path )
-		inputFile.renameTo( new File( inputFile.path.replace( ".js", ".tmp" ) ) )
-		inputFile = new File( inputFile.path.replace( ".js", ".tmp" ) )
+        def eachFileHandler = { File file ->
+            if(!file.isDirectory() && file.path.contains('.coffee')) {
+                defer { compileFile(file, minifyJS, wrapJS, overrideJS) }
+            }
+        }
 
-		try {
-			Resource resource = Resource.create( inputFile.path, ResourceType.JS );
-			Reader reader = new FileReader( inputFile.path );
-			Writer writer = new FileWriter( targetFile.path );
-			new UglifyJsProcessor().process( resource, reader, writer );
-			inputFile.delete()
-		}
-		catch ( Exception e )
-		{
-			inputFile.renameTo( new File( inputFile.path.replace( ".tmp", ".js" ) ) )
-			throw e
-		}
-	}
+        def ignoreHidden = { File file ->
+            !file.isHidden()
+        }
+
+        eachFileRecurse(coffeeSource, eachFileHandler, ignoreHidden)
+
+        pool.shutdown()
+        pool.awaitTermination(MINUTES_TO_WAIT_FOR_COMPLETE, TimeUnit.MINUTES)
+    }
+
+    def eachFileRecurse(File dir, Closure closure, Closure filter = { true }) {
+        dir.listFiles().each { file ->
+            if(filter.call(file)) {
+                if(file.isDirectory()) {
+                    eachFileRecurse(file, closure, filter)
+                } else {
+                    closure.call(file)
+                }
+            }
+        }
+    }
+
+    def minify(File inputFile) {
+        File targetFile = new File(inputFile.path)
+        inputFile.renameTo(new File(inputFile.path.replace('.js', '.tmp')))
+        inputFile = new File(inputFile.path.replace('.js', '.tmp'))
+
+        try {
+            Resource resource = Resource.create(inputFile.path, ResourceType.JS)
+            Reader reader = new FileReader(inputFile.path)
+            Writer writer = new FileWriter(targetFile.path)
+            new UglifyJsProcessor().process(resource, reader, writer)
+            inputFile.delete()
+        } catch(Exception e) {
+            inputFile.renameTo(new File(inputFile.path.replace('.tmp', '.js')))
+            log.error e.message, e
+            throw e
+        }
+    }
 
 }

--- a/src/groovy/org/grails/plugins/coffee/compiler/processor/CoffeeScriptProcessor.groovy
+++ b/src/groovy/org/grails/plugins/coffee/compiler/processor/CoffeeScriptProcessor.groovy
@@ -1,0 +1,97 @@
+package org.grails.plugins.coffee.compiler.processor
+
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+import ro.isdc.wro.model.group.Inject
+import ro.isdc.wro.model.group.processor.Injector
+import ro.isdc.wro.model.resource.Resource
+import ro.isdc.wro.model.resource.ResourceType
+import ro.isdc.wro.model.resource.SupportedResourceType
+import ro.isdc.wro.model.resource.processor.ResourcePostProcessor
+import ro.isdc.wro.model.resource.processor.ResourcePreProcessor
+import ro.isdc.wro.model.resource.processor.decorator.LazyProcessorDecorator
+import ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator
+import ro.isdc.wro.util.LazyInitializer
+
+/**
+ * Similar to {@link ro.isdc.wro.extensions.processor.js.RhinoCoffeeScriptProcessor} but will prefer using {@link ro.isdc.wro.extensions.processor.js.NodeCoffeeScriptProcessor} if it is supported and
+ * will fallback to rhino based processor.<br/>
+ *
+ * @author Alex Objelean
+ * @since 1.6.0
+ * @created 11 Sep 2012
+ */
+@SupportedResourceType(ResourceType.JS)
+class CoffeeScriptProcessor
+implements ResourcePreProcessor, ResourcePostProcessor {
+
+    private static final Log log = LogFactory.getLog(CoffeeScriptProcessor)
+    @Inject
+    private Injector injector
+    private ResourcePreProcessor resourcePreProcessor
+    private Boolean wrapJS = true
+
+    CoffeeScriptProcessor(Boolean wrapJS) {
+        this.wrapJS = wrapJS
+    }
+/**
+ * Responsible for coffeeScriptProcessor initialization. First the nodeCoffeeScript processor will be used as a primary processor. If
+ * it is not supported, the fallback processor will be used.
+ */
+    private ResourcePreProcessor initializeProcessor() {
+        final ProcessorDecorator processor = new ProcessorDecorator(createNodeProcessor())
+        processor.isSupported() ? processor : createRhinoProcessor()
+    }
+
+    /**
+     * @return {@link ResourcePreProcessor} used as a primary processor.
+     * @VisibleForTesting
+     */
+    ResourcePreProcessor createNodeProcessor() {
+        log.debug("creating NodeCoffeeScript processor")
+        new NodeCoffeeScriptProcessor(wrapJS)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void process(final Resource resource, final Reader reader, final Writer writer)
+    throws IOException {
+        getProcessor().process(resource, reader, writer)
+    }
+
+    public ResourcePreProcessor getProcessor() {
+        if(resourcePreProcessor == null) {
+            resourcePreProcessor = initializeProcessor()
+            injector.inject(resourcePreProcessor)
+        }
+        resourcePreProcessor
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void process(final Reader reader, final Writer writer)
+    throws IOException {
+        process(null, reader, writer)
+    }
+
+    /**
+     * Lazily initialize the rhinoProcessor.
+     *
+     * @return {@link ResourcePreProcessor} used as a fallback processor.
+     * @VisibleFortesTesting
+     */
+    public ResourcePreProcessor createRhinoProcessor() {
+        log.debug("Node CoffeeScript is not supported. Using fallback Rhino processor")
+        return new LazyProcessorDecorator(new LazyInitializer<ResourcePreProcessor>() {
+
+            @Override
+            protected ResourcePreProcessor initialize() {
+                new RhinoCoffeeScriptProcessor(wrapJS)
+            }
+        })
+    }
+}

--- a/src/groovy/org/grails/plugins/coffee/compiler/processor/NodeCoffeeScriptProcessor.groovy
+++ b/src/groovy/org/grails/plugins/coffee/compiler/processor/NodeCoffeeScriptProcessor.groovy
@@ -1,0 +1,206 @@
+package org.grails.plugins.coffee.compiler.processor
+
+
+import static org.apache.commons.lang3.Validate.notNull
+
+import java.text.MessageFormat
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.IOUtils
+import org.apache.commons.io.input.AutoCloseInputStream
+import ro.isdc.wro.WroRuntimeException
+import ro.isdc.wro.model.resource.Resource
+import ro.isdc.wro.model.resource.ResourceType
+import ro.isdc.wro.model.resource.SupportedResourceType
+import ro.isdc.wro.model.resource.processor.ResourcePostProcessor
+import ro.isdc.wro.model.resource.processor.ResourcePreProcessor
+import ro.isdc.wro.model.resource.processor.SupportAware
+import ro.isdc.wro.util.WroUtil
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+
+/**
+ * Important node: this processor is not cross platform and has some pre-requesites in order to work.
+ * Installation instructions:
+ *
+ * <pre>
+ *   npm install -g coffee-script
+ * </pre>
+ *
+ * It is possible to test whether the lessc utility is available using {@link NodeCoffeeScriptProcessor#isSupported()}
+ * <p/>
+ *
+ * @author Alex Objelean
+ * @since 1.5.0
+ * @created 10 Sep 2012
+ */
+@SupportedResourceType(ResourceType.JS)
+class NodeCoffeeScriptProcessor implements ResourcePreProcessor, ResourcePostProcessor, SupportAware {
+    private static final Log log = LogFactory.getLog(NodeCoffeeScriptProcessor)
+    /**
+     * Options passed to coffee command. -c is for compile, -p is for print to stdout.
+     */
+    private static final String OPTION_COMPILE = "-cp"
+    private static final String SHELL_COMMAND = "coffee"
+    Boolean wrapJS = true
+
+    /**
+     * Flag indicating that we are running on Windows platform. This will be initialized only once in constructor.
+     */
+    private final boolean isWindows
+
+    NodeCoffeeScriptProcessor(Boolean wrapJS = true) {
+        // initialize this field at construction.
+        this.wrapJS = wrapJS
+        final String osName = System.getProperty("os.name")
+        log.debug("OS Name:  ${osName}")
+        isWindows = osName != null && osName.contains("Windows")
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+
+    public void process(final Resource resource, final Reader reader, final Writer writer)
+    throws IOException {
+        log.debug("processing ${resource} resource")
+        final String content = IOUtils.toString(reader)
+        final String resourceUri = resource == null ? "unknown.coffee" : resource.getUri()
+        try {
+            writer.write(processData(resourceUri, content))
+        } catch (final Exception e) {
+            log.warn("Exception while applying " + getClass().getSimpleName() + " processor on the " + resourceUri
+                             + " resource, no processing applied...", e)
+            log.error(e.getMessage(), e)
+            onException(e, content)
+        } finally {
+            // return for later reuse
+            reader.close()
+            writer.close()
+        }
+    }
+
+    private String processData(final String resourceUri, final String content) {
+        final InputStream shellIn = null
+        // the file holding the input file to process
+        File temp = null
+        try {
+            temp = WroUtil.createTempFile()
+            final String encoding = "UTF-8"
+            IOUtils.write(content, new FileOutputStream(temp), encoding)
+            log.debug("absolute path: ${temp.getAbsolutePath()}" )
+
+            final Process process = createProcess(temp)
+            final String result = IOUtils.toString(new AutoCloseInputStream(process.getInputStream()), encoding)
+            final int exitStatus = process.waitFor()// this won't return till `out' stream being flushed!
+            if (exitStatus != 0) {
+                final String compileError = result
+                log.error("exitStatus: ${exitStatus}")
+                // find a way to get rid of escape character found at the end (minor issue)
+                final String errorMessage = MessageFormat.format("Error in CoffeeScript: \n{0}",
+                                                                 compileError.replace(temp.getPath(), resourceUri))
+                throw new WroRuntimeException(errorMessage)
+            }
+            //the result is compiled in the same file
+            return result
+        } catch (final Exception e) {
+            throw WroRuntimeException.wrap(e)
+        } finally {
+            IOUtils.closeQuietly(shellIn)
+            // always cleanUp
+            FileUtils.deleteQuietly(temp)
+        }
+    }
+
+    /**
+     * Invoked when a processing exception occurs. Default implementation wraps the original exception into
+     * {@link WroRuntimeException}.
+     *
+     * @param e
+     *          the {@link Exception} thrown during processing
+     * @param content
+     *          the resource content being processed.
+     */
+    protected void onException(final Exception e, final String content) {
+        throw WroRuntimeException.wrap(e)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+
+    public void process(final Reader reader, final Writer writer)
+    throws IOException {
+        process(null, reader, writer)
+    }
+
+    /**
+     * Creates process responsible for running lessc shell command by reading the file content from the sourceFilePath
+     *
+     * @param sourceFile
+     *          the source path of the file from where the lessc will read the less file.
+     * @throws IOException
+     *           when the process execution fails.
+     */
+    private Process createProcess(final File sourceFile)
+    throws IOException {
+        notNull(sourceFile)
+        final String[] commandLine = getCommandLine(sourceFile.getPath())
+        log.debug("CommandLine arguments: ${Arrays.asList(commandLine)}")
+        return new ProcessBuilder(commandLine).redirectErrorStream(true).start()
+    }
+
+    /**
+     * @return true if the processor is supported on this environment. The implementation check if the required shell
+     *         utility is available.
+     */
+    @Override
+    public boolean isSupported() {
+        File temp = null
+        try {
+            temp = WroUtil.createTempFile()
+            final Process process = createProcess(temp)
+            final int exitValue = process.waitFor()
+            log.debug "exitValue ${exitValue}. ErrorMessage: ${IOUtils.toString(process.getInputStream()) as String}"
+            if (exitValue != 0) {
+                throw new UnsupportedOperationException("Lessc is not a supported operation on this platform")
+            }
+            log.debug "The NodeCoffeeSript processor is supported."
+            return true
+        } catch (final Exception e) {
+            log.debug("The NodeCoffeeSript processor is not supported. Because: ${e.message as String}" )
+            return false
+        } finally {
+            FileUtils.deleteQuietly(temp)
+        }
+    }
+
+    /**
+     * Creates the platform specific arguments to run the <code>lessc</code> shell utility. Default implementation handles
+     * windows and unix platforms.
+     *
+     * @return arguments for command line. The implementation will take care of OS differences.
+     */
+    protected String[] getCommandLine(final String filePath) {
+        return isWindows ? buildArgumentsForWindows(filePath) : buildArgumentsForUnix(filePath)
+    }
+
+    /**
+     * @return arguments required to run lessc on non Windows platform.
+     */
+    private String[] buildArgumentsForUnix(final String filePath) {
+        [SHELL_COMMAND, OPTION_COMPILE + addNoWrap(), filePath]
+    }
+
+    /**
+     * @return arguments required to run lessc on Windows platform.
+     */
+    private String[] buildArgumentsForWindows(final String filePath) {
+        ["cmd", "/c", SHELL_COMMAND, OPTION_COMPILE +  addNoWrap(), filePath]
+    }
+
+    private String addNoWrap(){
+        (!wrapJS) ? "b" : ""
+    }
+
+
+}

--- a/src/groovy/org/grails/plugins/coffee/compiler/processor/RhinoCoffeeScriptProcessor.groovy
+++ b/src/groovy/org/grails/plugins/coffee/compiler/processor/RhinoCoffeeScriptProcessor.groovy
@@ -1,0 +1,84 @@
+package org.grails.plugins.coffee.compiler.processor
+
+import org.apache.commons.io.IOUtils
+import org.apache.commons.lang3.StringUtils
+import ro.isdc.wro.WroRuntimeException
+import ro.isdc.wro.extensions.processor.support.ObjectPoolHelper
+import ro.isdc.wro.extensions.processor.support.coffeescript.CoffeeScript
+import ro.isdc.wro.model.resource.Resource
+import ro.isdc.wro.model.resource.ResourceType
+import ro.isdc.wro.model.resource.SupportedResourceType
+import ro.isdc.wro.model.resource.processor.ResourcePostProcessor
+import ro.isdc.wro.model.resource.processor.ResourcePreProcessor
+import ro.isdc.wro.util.ObjectFactory
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+
+@SupportedResourceType(ResourceType.JS)
+class RhinoCoffeeScriptProcessor implements ResourcePreProcessor, ResourcePostProcessor {
+    private static final Log log = LogFactory.getLog(RhinoCoffeeScriptProcessor)
+    ObjectPoolHelper<CoffeeScript> enginePool
+
+    public RhinoCoffeeScriptProcessor(Boolean wrapJS = true) {
+        enginePool = new ObjectPoolHelper<CoffeeScript>(new ObjectFactory<CoffeeScript>() {
+            @Override
+            CoffeeScript create() {
+                newCoffeeScript(wrapJS)
+            }
+        })
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void process(final Resource resource, final Reader reader, final Writer writer)
+    throws IOException {
+        final String content = IOUtils.toString(reader)
+        final CoffeeScript coffeeScript = enginePool.getObject()
+        try {
+            writer << coffeeScript.compile(content)
+        } catch (final Exception e) {
+            onException(e)
+            final String resourceUri = resource == null ? StringUtils.EMPTY : "[" + resource.getUri() + "]"
+            log.error("Exception while applying " + getClass().getSimpleName() + " processor on the " + resourceUri
+                              + " resource, no processing applied...", e)
+        } finally {
+            reader.close()
+            writer.close()
+            enginePool.returnObject(coffeeScript)
+        }
+    }
+
+    /**
+     * Invoked when a processing exception occurs.
+     */
+    protected void onException(final Exception e) {
+        throw WroRuntimeException.wrap(e)
+    }
+
+    /**
+     * @return the {@link CoffeeScript} engine implementation. Override it to provide a different version of the coffeeScript.js
+     *         library. Useful for upgrading the processor outside the wro4j release.
+     */
+    protected CoffeeScript newCoffeeScript(Boolean wrapJS = true) {
+        CoffeeScript cs = new CoffeeScript()
+        if(!wrapJS){
+//            cs.setOptions("noWrap")
+//            cs.setOptions("no-wrap")
+            cs.setOptions("bare")
+            //why does bare work?  Thought they moved it to noWrap (--no-wrap)?!
+        }
+        cs
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void process(final Reader reader, final Writer writer)
+    throws IOException {
+        process(null, reader, writer)
+    }
+}
+

--- a/test/integration/coffeescript/compiler/PluginSpec.groovy
+++ b/test/integration/coffeescript/compiler/PluginSpec.groovy
@@ -1,0 +1,306 @@
+package coffeescript.compiler
+
+import grails.plugin.spock.IntegrationSpec
+import org.grails.plugins.coffee.compiler.CoffeeCompilerManager
+import ro.isdc.wro.WroRuntimeException
+
+/**
+ */
+class PluginSpec extends IntegrationSpec {
+
+    def cleanup() {
+        new File("src/coffee").deleteDir()
+        new File("web-app/js").deleteDir()
+    }
+
+    def "test that compiler will wrap with call method by default"() {
+        given:
+        String coffeePath = "web-app/js/app"
+        String javascriptPath = "web-app/js/app"
+        String fileName = "testWithConfig"
+        File javascriptFile = createValidJavascriptFile(javascriptPath, fileName)
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath, purgeJS: false)
+        javascriptFile.setLastModified(new Date().time - 110000)
+
+        then: 'ensure existing js exists still'
+        javascriptFile.exists()
+
+        when:
+        def coffeeFile = createValidCoffeeFile(coffeePath, fileName)
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then: "if user created js file after coffee or modified manually, print error but don't change it"
+        javascriptFile.exists()
+        javascriptFile.lastModified() >= coffeeFile.lastModified()
+
+        and: 'file contains correct syntax'
+        javascriptFile.text.contains("call")
+        javascriptFile.text.contains("someFunctionCall")
+        println javascriptFile.text
+    }
+
+    def "test that nowrap causes compiler to not wrap coffeescript in call method"() {
+        given:
+        String coffeePath = "web-app/js/app"
+        String javascriptPath = "web-app/js/app"
+        String fileName = "testWithConfig"
+        File javascriptFile = createValidJavascriptFile(javascriptPath, fileName)
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath, purgeJS: false, wrapJS: false)
+        javascriptFile.setLastModified(new Date().time - 110000)
+
+        then: 'ensure existing js exists still'
+        javascriptFile.exists()
+
+        when:
+        def coffeeFile = createValidCoffeeFile(coffeePath, fileName)
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then: "if user created js file after coffee or modified manually, print error but don't change it"
+        javascriptFile.exists()
+        javascriptFile.lastModified() >= coffeeFile.lastModified()
+
+        and: 'file contains correct syntax'
+        !javascriptFile.text.contains("call")
+        javascriptFile.text.contains("someFunctionCall")
+    }
+
+    def "use same coffees and javascript folders"() {
+        given:
+        String coffeePath = "web-app/js/app"
+        String javascriptPath = "web-app/js/app"
+        String fileName = "testWithConfig"
+        File javascriptFile = createValidJavascriptFile(javascriptPath, fileName)
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath, purgeJS: false)
+        javascriptFile.setLastModified(new Date().time - 110000)
+
+        then: 'ensure existing js exists still'
+        javascriptFile.exists()
+
+        when:
+        def coffeeFile = createValidCoffeeFile(coffeePath, fileName)
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then: "if user created js file after coffee or modified manually, print error but don't change it"
+        javascriptFile.exists()
+        javascriptFile.lastModified() >= coffeeFile.lastModified()
+
+        and: 'file contains correct syntax'
+        !javascriptFile.text.contains("alert")
+        javascriptFile.text.contains("someFunctionCall")
+    }
+
+    def "ensure older js files are overridden"() {
+        given:
+        String coffeePath = "src/coffee/app"
+        String javascriptPath = "web-app/js/app"
+        String fileName = "testWithConfig"
+        File javascriptFile = createValidJavascriptFile(javascriptPath, fileName)
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath, purgeJS: false)
+        javascriptFile.setLastModified(new Date().time - 110000)
+
+        then: 'ensure existing js exists still'
+        javascriptFile.exists()
+
+        when:
+        def coffeeFile = createValidCoffeeFile(coffeePath, fileName)
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then: "if user created js file after coffee or modified manually, print error but don't change it"
+        javascriptFile.exists()
+        javascriptFile.lastModified() >= coffeeFile.lastModified()
+
+        and: 'file contains correct syntax'
+        !javascriptFile.text.contains("alert")
+        javascriptFile.text.contains("someFunctionCall")
+    }
+
+    def "ensure newer js files aren't overridden"() {
+        given:
+        String coffeePath = "src/coffee/app"
+        String javascriptPath = "web-app/js/app"
+        String fileName = "testWithConfig"
+        File javascriptFile = createValidJavascriptFile(javascriptPath, fileName)
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath, purgeJS: false, overrideJS: false)
+        javascriptFile.setLastModified(new Date().time + 110000)
+
+        then: 'ensure existing js exists still'
+        javascriptFile.exists()
+
+        when:
+        def coffeeFile = createValidCoffeeFile(coffeePath, fileName)
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then: "if user created js file after coffee or modified manually, print error but don't change it"
+        javascriptFile.exists()
+        javascriptFile.lastModified() >= coffeeFile.lastModified()
+
+        and: 'file contains correct syntax'
+        javascriptFile.text.contains("alert")
+        !javascriptFile.text.contains("someFunctionCall")
+    }
+
+    def "ensure newer js files are overridden by default"() {
+        given:
+        String coffeePath = "src/coffee/app"
+        String javascriptPath = "web-app/js/app"
+        String fileName = "testWithConfig"
+        File javascriptFile = createValidJavascriptFile(javascriptPath, fileName)
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath, purgeJS: false)
+        javascriptFile.setLastModified(new Date().time + 110000)
+
+        then: 'ensure existing js exists still'
+        javascriptFile.exists()
+
+        when:
+        def coffeeFile = createValidCoffeeFile(coffeePath, fileName)
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then: "if user created js file after coffee or modified manually then it should be changed by default"
+        javascriptFile.exists()
+        javascriptFile.lastModified() >= coffeeFile.lastModified()
+        !javascriptFile.text.contains("alert")
+
+        and: 'file contains correct syntax'
+        javascriptFile.text.contains("someFunctionCall")
+    }
+
+    def "set the purgeJS flag to false and ensure files stay in tact"() {
+        given:
+        String coffeePath = "src/coffee/app"
+        String javascriptPath = "web-app/js/app"
+        File someOtherFile = createValidJavascriptFile(javascriptPath, "testWithConfig2")
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath, purgeJS: false)
+
+        then: 'ensure existing js exists still'
+        someOtherFile.exists()
+
+        when:
+        createValidCoffeeFile(coffeePath, "testWithConfig")
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then:
+        new File("${javascriptPath}/testWithConfig.js").exists()
+        someOtherFile.exists()
+
+        and: 'file contains correct syntax'
+        someOtherFile.text.contains('alert')
+
+    }
+
+    def "set the purgeJS flag to default of true and ensure files are purged"() {
+        given:
+        String coffeePath = "src/coffee/app"
+        String javascriptPath = "web-app/js/app"
+        File someOtherFile = createValidJavascriptFile(javascriptPath, "testWithConfig2")
+
+        when:
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath)
+
+        then: 'ensure existing js exists still'
+        someOtherFile.exists()
+
+        when:
+        createValidCoffeeFile(coffeePath, "testWithConfig")
+        def config = createPluginConfig([:], "myApp", coffeePath, javascriptPath)
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
+
+        then: 'coffee to js exists but other original js file does not'
+        def javascriptFile = new File("${javascriptPath}/testWithConfig.js")
+        javascriptFile.exists()
+        !someOtherFile.exists()
+
+        and: 'file contains correct syntax'
+        javascriptFile.text.contains('someFunctionCall')
+    }
+
+    def "test invalid coffees file"() {
+        given:
+        String coffeePath = "src/coffee"
+        String javascriptPath = "web-app/js/app"
+        CoffeeCompilerManager compilerManager = new CoffeeCompilerManager(defaultJsOutputPath: javascriptPath, defaultCoffeeSourcePath: coffeePath)
+
+        when:
+        createInvalidCoffeeFile(coffeePath, "myBadFile")
+        compilerManager.compileFileFromConfig(new File("${coffeePath}/myBadFile.coffee"), [:])
+
+        then:
+        thrown(WroRuntimeException)
+    }
+
+    def createPluginConfig(configMap, configName, coffeeSourcePath, jsOutputPath) {
+        def paths = [coffeeSourcePath: coffeeSourcePath, jsOutputPath: jsOutputPath]
+
+        if(!configMap.containsKey("coffeescript-compiler"))
+            configMap["coffeescript-compiler"] = [:]
+
+        configMap["coffeescript-compiler"][configName] = paths
+        return configMap
+    }
+
+    def createValidJavascriptFile(String path, String name) {
+        String content = """
+alert('hello');
+"""
+        new File(path).mkdirs()
+        File file = new File("${path}/${name}.js")
+        file.setWritable(true)
+        file << content
+        assert file.exists()
+        file
+    }
+
+    def createValidCoffeeFile(String path, String name) {
+        String content = """
+someVar = 'my var value'
+someFunctionCall( someVar, [ 'element1', 'element2' ] )
+"""
+        new File(path).mkdirs()
+        File file = new File("${path}/${name}.coffee")
+        file.setWritable(true)
+        file << content
+        assert file.exists()
+        file
+    }
+
+    def createInvalidCoffeeFile(String path, String name) {
+        String content = """
+someVar = 'my var value'
+someFunctionCall( someVar, [ 'element1', 'element2' )
+"""
+        new File(path).mkdirs()
+        File file = new File("${path}/${name}.coffee")
+        file.setWritable(true)
+        file << content
+        assert file.exists()
+        file
+    }
+}

--- a/test/integration/coffeescript/compiler/PluginTestTests.groovy
+++ b/test/integration/coffeescript/compiler/PluginTestTests.groovy
@@ -1,190 +1,188 @@
 package coffeescript.compiler
 
 import org.grails.plugins.coffee.compiler.CoffeeCompilerManager
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
 import ro.isdc.wro.WroRuntimeException
 
-import static org.junit.Assert.*
-import org.junit.*
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
 
 class PluginTestTests {
 
-	CoffeeCompilerManager compilerManager
+    CoffeeCompilerManager compilerManager
 
     @Before
     void setUp() {
-		compilerManager = new CoffeeCompilerManager()
+        compilerManager = new CoffeeCompilerManager()
     }
 
     @After
     void tearDown() {
-		new File( "src/coffee" ).deleteDir()
-		new File( "web-app/js" ).deleteDir()
+        new File("src/coffee").deleteDir()
+        new File("web-app/js").deleteDir()
     }
 
-	@Test
-	void testDefaultConfig()
-	{
-		createValidCoffeeFile( "src/coffee", "testDefaultConfig" )
-		compilerManager.compileFromConfig( [:] )
-		sleep( 1000 ) // Poor-man's thread wait solution
+    @Test
+    void testDefaultConfig() {
+        createValidCoffeeFile("src/coffee", "testDefaultConfig")
+        compilerManager.compileFromConfig([:])
+        sleep(1000) // Poor-man's thread wait solution
 
-		def jsFile = new File( "web-app/js/app/testDefaultConfig.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
-	}
+        def jsFile = new File("web-app/js/app/testDefaultConfig.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
+    }
 
-	@Test
-	void testWithConfig()
-	{
-		createValidCoffeeFile( "src/coffee/app", "testWithConfig" )
-		def config = createPluginConfig( [:], "myApp", "src/coffee/app", "web-app/js/app" )
-		compilerManager.compileFromConfig( config )
-		sleep( 1000 ) // Poor-man's thread wait solution
+    @Test
+    void testWithConfig() {
+        createValidCoffeeFile("src/coffee/app", "testWithConfig")
+        def config = createPluginConfig([:], "myApp", "src/coffee/app", "web-app/js/app")
+        compilerManager.compileFromConfig(config)
+        sleep(1000) // Poor-man's thread wait solution
 
-		def jsFile = new File( "web-app/js/app/testWithConfig.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
-	}
+        def jsFile = new File("web-app/js/app/testWithConfig.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
+    }
 
-	@Test
-	void testCoffeeSourceTree()
-	{
-		createValidCoffeeFile( "src/coffee/app", "testCoffeeSourceTree1" )
-		createValidCoffeeFile( "src/coffee/app/child", "testCoffeeSourceTree2" )
-		createValidCoffeeFile( "src/coffee/app/child/subchild", "testCoffeeSourceTree3" )
+    @Test
+    void testCoffeeSourceTree() {
+        createValidCoffeeFile("src/coffee/app", "testCoffeeSourceTree1")
+        createValidCoffeeFile("src/coffee/app/child", "testCoffeeSourceTree2")
+        createValidCoffeeFile("src/coffee/app/child/subchild", "testCoffeeSourceTree3")
 
-		def config = createPluginConfig( [:], "myApp", "src/coffee/app", "web-app/js/app" )
-		compilerManager.compileFromConfig( config )
-		sleep( 1500 ) // Poor-man's thread wait solution
+        def config = createPluginConfig([:], "myApp", "src/coffee/app", "web-app/js/app")
+        compilerManager.compileFromConfig(config)
+        sleep(1500) // Poor-man's thread wait solution
 
-		def jsFile
-		jsFile = new File( "web-app/js/app/testCoffeeSourceTree1.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        def jsFile
+        jsFile = new File("web-app/js/app/testCoffeeSourceTree1.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/app/child/testCoffeeSourceTree2.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/app/child/testCoffeeSourceTree2.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/app/child/subchild/testCoffeeSourceTree3.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
-	}
+        jsFile = new File("web-app/js/app/child/subchild/testCoffeeSourceTree3.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
+    }
 
-	@Test
-	void testCoffeeSourceTreeIgnoresHiddenPaths()
-	{
-		createValidCoffeeFile( "src/coffee/app", "testCoffeeSourceTree1" )
-		createValidCoffeeFile( "src/coffee/app/child", "testCoffeeSourceTree2" )
-		createValidCoffeeFile( "src/coffee/app/child/subchild", "testCoffeeSourceTree3" )
-		createValidCoffeeFile( "src/coffee/app/hidden", "testCoffeeSourceTreeHidden1" )
-		createValidCoffeeFile( "src/coffee/app/hidden/child", "testCoffeeSourceTreeHidden2" )
+    @Test
+    void testCoffeeSourceTreeIgnoresHiddenPaths() {
+        createValidCoffeeFile("src/coffee/app", "testCoffeeSourceTree1")
+        createValidCoffeeFile("src/coffee/app/child", "testCoffeeSourceTree2")
+        createValidCoffeeFile("src/coffee/app/child/subchild", "testCoffeeSourceTree3")
+        createValidCoffeeFile("src/coffee/app/hidden", "testCoffeeSourceTreeHidden1")
+        createValidCoffeeFile("src/coffee/app/hidden/child", "testCoffeeSourceTreeHidden2")
 
-		// Mark app/hidden folder as hidden on Windows
-		Process p = Runtime.getRuntime().exec( "attrib +H " + new File( "src/coffee/app/hidden" ).getPath() )
-		p.waitFor();
+        // Mark app/hidden folder as hidden on Windows
+        if(System.getProperty("os.name").contains("Windows")) {
+            Process p = Runtime.runtime.exec("attrib +H " + new File("src/coffee/app/hidden").getPath())
+            p.waitFor();
+        }
 
-		def config = createPluginConfig( [:], "myApp", "src/coffee/app", "web-app/js/app" )
-		compilerManager.compileFromConfig( config )
-		sleep( 1500 ) // Poor-man's thread wait solution
+        def config = createPluginConfig([:], "myApp", "src/coffee/app", "web-app/js/app")
+        compilerManager.compileFromConfig(config)
+        sleep(1500) // Poor-man's thread wait solution
 
-		def jsFile
-		jsFile = new File( "web-app/js/app/testCoffeeSourceTree1.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        def jsFile
+        jsFile = new File("web-app/js/app/testCoffeeSourceTree1.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/app/child/testCoffeeSourceTree2.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/app/child/testCoffeeSourceTree2.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/app/child/subchild/testCoffeeSourceTree3.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/app/child/subchild/testCoffeeSourceTree3.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/app/testCoffeeSourceTree1.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/app/testCoffeeSourceTree1.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "src/coffee/app/hidden/testCoffeeSourceTreeHidden1.js" )
-		assertFalse( "Generated file ${jsFile.path} from hidden source folder should not exist", jsFile.exists() )
+        jsFile = new File("src/coffee/app/hidden/testCoffeeSourceTreeHidden1.js")
+        assertFalse("Generated file ${jsFile.path} from hidden source folder should not exist", jsFile.exists())
 
-		jsFile = new File( "src/coffee/app/hidden/child/testCoffeeSourceTreeHidden2.js" )
-		assertFalse( "Generated file ${jsFile.path} from hidden source folder should not exist", jsFile.exists() )
-	}
+        jsFile = new File("src/coffee/app/hidden/child/testCoffeeSourceTreeHidden2.js")
+        assertFalse("Generated file ${jsFile.path} from hidden source folder should not exist", jsFile.exists())
+    }
 
-	@Test
-	void testMultipleCoffeeSourceTrees()
-	{
-		createValidCoffeeFile( "src/coffee/app", "testMultipleCoffeeSourceTrees1" )
-		createValidCoffeeFile( "src/coffee/app/child", "testMultipleCoffeeSourceTrees2" )
-		createValidCoffeeFile( "src/coffee/app/child/subchild", "testMultipleCoffeeSourceTrees3" )
-		createValidCoffeeFile( "src/coffee/spec", "testMultipleCoffeeSourceTrees4" )
-		createValidCoffeeFile( "src/coffee/spec/child", "testMultipleCoffeeSourceTrees5" )
-		createValidCoffeeFile( "src/coffee/spec/child/subchild", "testMultipleCoffeeSourceTrees6" )
+    @Test
+    void testMultipleCoffeeSourceTrees() {
+        createValidCoffeeFile("src/coffee/app", "testMultipleCoffeeSourceTrees1")
+        createValidCoffeeFile("src/coffee/app/child", "testMultipleCoffeeSourceTrees2")
+        createValidCoffeeFile("src/coffee/app/child/subchild", "testMultipleCoffeeSourceTrees3")
+        createValidCoffeeFile("src/coffee/spec", "testMultipleCoffeeSourceTrees4")
+        createValidCoffeeFile("src/coffee/spec/child", "testMultipleCoffeeSourceTrees5")
+        createValidCoffeeFile("src/coffee/spec/child/subchild", "testMultipleCoffeeSourceTrees6")
 
-		def config = createPluginConfig( [:], "myApp", "src/coffee/app", "web-app/js/app" )
-		config = createPluginConfig( config, "myTests", "src/coffee/spec", "web-app/js/spec" )
-		compilerManager.compileFromConfig( config )
-		sleep( 2000 ) // Poor-man's thread wait solution
+        def config = createPluginConfig([:], "myApp", "src/coffee/app", "web-app/js/app")
+        config = createPluginConfig(config, "myTests", "src/coffee/spec", "web-app/js/spec")
+        compilerManager.compileFromConfig(config)
+        sleep(2000) // Poor-man's thread wait solution
 
-		def jsFile
-		jsFile = new File( "web-app/js/app/testMultipleCoffeeSourceTrees1.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        def jsFile
+        jsFile = new File("web-app/js/app/testMultipleCoffeeSourceTrees1.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/app/child/testMultipleCoffeeSourceTrees2.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/app/child/testMultipleCoffeeSourceTrees2.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/app/child/subchild/testMultipleCoffeeSourceTrees3.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/app/child/subchild/testMultipleCoffeeSourceTrees3.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/spec/testMultipleCoffeeSourceTrees4.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/spec/testMultipleCoffeeSourceTrees4.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/spec/child/testMultipleCoffeeSourceTrees5.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
+        jsFile = new File("web-app/js/spec/child/testMultipleCoffeeSourceTrees5.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
 
-		jsFile = new File( "web-app/js/spec/child/subchild/testMultipleCoffeeSourceTrees6.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
-	}
+        jsFile = new File("web-app/js/spec/child/subchild/testMultipleCoffeeSourceTrees6.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
+    }
 
-	@Test( expected=WroRuntimeException )
-	void testInvalidCoffeeScript()
-	{
-		createInvalidCoffeeFile( "src/coffee", "myBadFile" )
-		compilerManager.compileFileFromConfig( new File( "src/coffee/myBadFile.coffee" ), [:] )
-	}
+    @Test(expected = WroRuntimeException)
+    void testInvalidCoffeeScript() {
+        createInvalidCoffeeFile("src/coffee", "myBadFile")
+        compilerManager.compileFileFromConfig(new File("src/coffee/myBadFile.coffee"), [:])
+    }
 
-	@Test
-	void testCompileFile()
-	{
-		createValidCoffeeFile( "src/coffee", "testCompileFile" )
-		compilerManager.compileFileFromConfig( new File( "src/coffee/testCompileFile.coffee" ), [:] )
-		def jsFile = new File( "web-app/js/app/testCompileFile.js" )
-		assertTrue( "Generated file ${jsFile.path} does not exist", jsFile.exists() )
-	}
+    @Test
+    void testCompileFile() {
+        createValidCoffeeFile("src/coffee", "testCompileFile")
+        compilerManager.compileFileFromConfig(new File("src/coffee/testCompileFile.coffee"), [:])
+        def jsFile = new File("web-app/js/app/testCompileFile.js")
+        assertTrue("Generated file ${jsFile.path} does not exist", jsFile.exists())
+    }
 
+    // Helper methods
 
-	// Helper methods
+    def createPluginConfig(configMap, configName, coffeeSourcePath, jsOutputPath) {
+        def paths = [coffeeSourcePath: coffeeSourcePath, jsOutputPath: jsOutputPath]
 
-	def createPluginConfig( configMap, configName, coffeeSourcePath, jsOutputPath )
-	{
-		def paths = [ coffeeSourcePath : coffeeSourcePath, jsOutputPath : jsOutputPath ]
+        if(!configMap.containsKey("coffeescript-compiler"))
+            configMap["coffeescript-compiler"] = [:]
 
-		if(  !configMap.containsKey( "coffeescript-compiler" ) )
-			configMap[ "coffeescript-compiler" ] = [:]
+        configMap["coffeescript-compiler"][configName] = paths
+        return configMap
+    }
 
-		configMap[ "coffeescript-compiler" ][ configName ] = paths
-		return configMap
-	}
-
-	def createValidCoffeeFile( path, name )
-	{
-		String content = """
+    def createValidCoffeeFile(String path, String name) {
+        String content = """
 someVar = 'my var value'
 someFunctionCall( someVar, [ 'element1', 'element2' ] )
 """
-		new File( path ).mkdirs()
-		new File( "${path}/${name}.coffee" ).write( content )
-	}
+        new File(path).mkdirs()
+        File file = new File("${path}/${name}.coffee")
+        file << content
+        assertTrue "valid coffee file exists", file.exists()
+    }
 
-	def createInvalidCoffeeFile( path, name )
-	{
-		String content = """
+    def createInvalidCoffeeFile(String path, String name) {
+        String content = """
 someVar = 'my var value'
 someFunctionCall( someVar, [ 'element1', 'element2' )
 """
-		new File( path ).mkdirs()
-		new File( "${path}/${name}.coffee" ).write( content )
-	}
+        new File(path).mkdirs()
+        File file = new File("${path}/${name}.coffee")
+        file << content
+        assertTrue "bad coffee file exists", file.exists()
+    }
 }


### PR DESCRIPTION
- Adding support for wrapJS flag to turn on or off .call() wraper
- Adding support for purgeJS flag to tell the plugin to not wack the JS on startup (sometimes useful for when items are in a shared directory with non-coffee js files.
- Adding support for overrideJS flag to allow users to not override the js file from coffee when js is newer during startup.  Useful sometimes to debug if the coffee can't quite be worked out and person needs to work in js directly while debugging.
- Adding several integration specs to test these new changes.
- Ensured that both Node and Rhino processors worked (hard to test in automation - simply add `npm install coffee-script` and test then `npm remove coffee-script` and test again)
- Code cleanup

wro4j seems to lack the ability to pass in compiler flags to the coffee processors so I had to copy and augment them in the plugin.  I have asked the wro4j author for more details on this and hopefully support will be added in the future. See http://chat.stackoverflow.com/rooms/22709/wro4j.

C
