### PR TITLE
can force using Rhino via grails config file

### DIFF
--- a/CoffeescriptCompilerGrailsPlugin.groovy
+++ b/CoffeescriptCompilerGrailsPlugin.groovy
@@ -77,6 +77,7 @@ A simple CoffeeScript compiler plugin. It compiles .coffee source files into .js
 			coffeeCompilerManager.purgeJS = ( thisPluginConfig.containsKey( "purgeJS" ) ) ? thisPluginConfig.purgeJS as Boolean : false
 			coffeeCompilerManager.wrapJS = ( thisPluginConfig.containsKey( "wrapJS" ) ) ? thisPluginConfig.wrapJS as Boolean : true
 			coffeeCompilerManager.overrideJS = ( thisPluginConfig.containsKey( "overrideJS" ) ) ? thisPluginConfig.overrideJS as Boolean : true
+			coffeeCompilerManager.forceRhino = ( thisPluginConfig.containsKey( "forceRhino" ) ) ? thisPluginConfig.forceRhino as Boolean : false
 			coffeeCompilerManager.compileFromConfig( application.config )
 			startUpComplete = true
 		}

--- a/src/groovy/org/grails/plugins/coffee/compiler/CoffeeCompilerManager.groovy
+++ b/src/groovy/org/grails/plugins/coffee/compiler/CoffeeCompilerManager.groovy
@@ -2,6 +2,7 @@ package org.grails.plugins.coffee.compiler
 
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
+import org.grails.plugins.coffee.compiler.processor.CoffeeScriptProcessor
 
 class CoffeeCompilerManager
 {
@@ -12,6 +13,7 @@ class CoffeeCompilerManager
 	Boolean purgeJS = false
 	Boolean wrapJS = true
 	Boolean overrideJS = true
+	Boolean forceRhino = true
 	String defaultCoffeeSourcePath = 'src/coffee'
 	String defaultJsOutputPath = 'web-app/js/app'
 
@@ -31,7 +33,9 @@ class CoffeeCompilerManager
 		log.debug "purgeJS: ${ purgeJS }"
 		log.debug "overrideJS: ${ overrideJS }"
 		log.debug "wrapJS: ${ wrapJS }"
+		log.debug "forceRhino: ${ forceRhino }"
 
+        CoffeeScriptProcessor.forceRhino = this.forceRhino
 		compilePaths.each {
 			if( it.key != "pluginConfig" )
 			{


### PR DESCRIPTION
Whe you have installed  Node and Rhino, now you can force using Rhino via Config.groovy.
Example form Config.groovy

'coffeescript-compiler' {

```
pluginConfig {
    ...................
    forceRhino = true
}

appSource {
   .............
}
```

}
